### PR TITLE
[Mellanox] Add a column to display LED color to show platform psustatus output

### DIFF
--- a/scripts/psushow
+++ b/scripts/psushow
@@ -35,7 +35,7 @@ def psu_status_show(index):
     else:
         psu_ids = [index]
 
-    header = ['PSU', 'Status']
+    header = ['PSU', 'Status', 'LED']
     status_table = []
 
     for psu in psu_ids:
@@ -51,7 +51,8 @@ def psu_status_show(index):
             msg = 'OK' if oper_status == 'true' else "NOT OK"
         else:
             msg = 'NOT PRESENT'
-        status_table.append([psu_name, msg])
+        led_status = db.get(db.STATE_DB, 'PSU_INFO|{}'.format(psu_name), 'led_status')
+        status_table.append([psu_name, msg, led_status])
 
     if status_table:
         print tabulate(status_table, header, tablefmt="simple")

--- a/sonic-utilities-tests/mock_tables/state_db.json
+++ b/sonic-utilities-tests/mock_tables/state_db.json
@@ -53,11 +53,13 @@
     },
     "PSU_INFO|PSU 1": {
         "presence": "true",
-        "status": "true"
+        "status": "true",
+        "led_status": "green"
     },
     "PSU_INFO|PSU 2": {
         "presence": "true",
-        "status": "true"
+        "status": "true",
+        "led_status": "green"
     },
     "SWITCH_CAPABILITY|switch": {
         "MIRROR": "true",

--- a/sonic-utilities-tests/psu_test.py
+++ b/sonic-utilities-tests/psu_test.py
@@ -36,9 +36,9 @@ class TestPsu(object):
     def test_single_psu(self):
         runner = CliRunner()
         result = runner.invoke(show.cli.commands["platform"].commands["psustatus"], ["--index=1"])
-        expected = """PSU    Status
------  --------
-PSU 1  OK
+        expected = """PSU    Status    LED
+-----  --------  -----
+PSU 1  OK        green
 """
         assert result.output == expected
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**

Add a column to display LED color to show platform psustatus output.

**- How I did it**

Add a column "LED", it will display PSU physical LED color in command line output.

**- How to verify it**

1. Adjust existing unit test case
2. Add/adjust test cases to sonic-mgmt
3. Manual test

**- Previous command output (if the output of a command-line utility has changed)**

```
PSU    Status
-----  --------
PSU 1  OK
PSU 2  OK
```

**- New command output (if the output of a command-line utility has changed)**

```
PSU    Status    LED
-----  --------  -------
PSU 1  OK        green
PSU 2  OK        red
```