### PR TITLE
[config reload] [202012] Call systemctl reset-failed for snmp,telemetry,mgmt-framework services

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -701,12 +701,16 @@ def _stop_services():
 
 def _get_sonic_services():
     out = clicommon.run_command("systemctl list-dependencies --plain sonic.target | sed '1d'", return_cmd=True)
-    return [unit.strip() for unit in out.splitlines()]
+    return (unit.strip() for unit in out.splitlines())
+
+
+def _get_delayed_sonic_services():
+    out = clicommon.run_command("systemctl list-dependencies --plain sonic-delayed.target | sed '1d'", return_cmd=True)
+    return (unit.strip().rstrip('.timer') for unit in out.splitlines())
 
 
 def _reset_failed_services():
-    for service in _get_sonic_services():
-        click.echo("Resetting failed status on {}".format(service))
+    for service in itertools.chain(_get_sonic_services(), _get_delayed_sonic_services()):
         clicommon.run_command("systemctl reset-failed {}".format(service))
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -28,7 +28,13 @@ def mock_run_command_side_effect(*args, **kwargs):
         click.echo(click.style("Running command: ", fg='cyan') + click.style(command, fg='green'))
 
     if kwargs.get('return_cmd'):
-        return ''
+        if command == "systemctl list-dependencies --plain sonic-delayed.target | sed '1d'":
+            return 'snmp.timer'
+        elif command == "systemctl list-dependencies --plain sonic.target | sed '1d'":
+            return 'swss'
+        else:
+            return ''
+
 
 class TestLoadMinigraph(object):
     @classmethod
@@ -48,7 +54,11 @@ class TestLoadMinigraph(object):
             traceback.print_tb(result.exc_info[2])
             assert result.exit_code == 0
             assert "\n".join([l.rstrip() for l in result.output.split('\n')]) == load_minigraph_command_output
-            assert mock_run_command.call_count == 7
+            # Verify "systemctl reset-failed" is called for services under sonic.target 
+            mock_run_command.assert_any_call('systemctl reset-failed swss')
+            # Verify "systemctl reset-failed" is called for services under sonic-delayed.target 
+            mock_run_command.assert_any_call('systemctl reset-failed snmp')
+            assert mock_run_command.call_count == 10
 
     def test_load_minigraph_with_port_config_bad_format(self, get_cmd_module, setup_single_broadcom_asic):
         with mock.patch(


### PR DESCRIPTION
Back port PR https://github.com/Azure/sonic-utilities/pull/1773 to 202012 branch.

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

When issue `config reload -y` or `config load_minigraph -y` command, most of the sonic services will be reset by command `systemctl reset-failed <service_name>`. The purpose is to avoid services reach to its start retry limit and cannot be started. However, `systemctl reset-failed` only resets those services belong to sonic.target, snmp, telemetry and mgmt-framework are not part of them. So if we run `config reload -y` or `config load_minigraph -y` continues, snmp, telemetry and mgmt-framework services might enter into failed state. This PR is to fix the issue.

I would like to cherry-pick this fix to 202012 branch, but this fix also depends on PR https://github.com/Azure/sonic-buildimage/pull/7846. So if we decide to cherry-pick this PR to 202012, we need cherry-pick https://github.com/Azure/sonic-buildimage/pull/7846 first.

#### How I did it

Also call `systemctl reset-failed` for services like snmp, telemetry and mgmt-framework. 

#### How to verify it

Manual test.

#### Previous command output (if the output of a command-line utility has changed)

No command output changes.

#### New command output (if the output of a command-line utility has changed)

No command output changes.

