### PR TITLE
Adjust port-buffer-drop counter default interval from 60000ms to 10000ms

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -90,14 +90,10 @@ def port_buffer_drop():
     """ Port buffer drop  counter commands """
 
 @port_buffer_drop.command()
-@click.argument('poll_interval', type=click.IntRange(30000, 300000))
+@click.argument('poll_interval', type=click.IntRange(1000, 300000))
 def interval(poll_interval):
     """
     Set port_buffer_drop counter query interval
-    This counter group causes high CPU usage when polled,
-    hence the allowed interval is between 30s and 300s.
-    This is a short term solution and
-    should be changed once the performance is enhanced
     """
     configdb = ConfigDBConnector()
     configdb.connect()
@@ -262,7 +258,7 @@ def show():
     if port_info:
         data.append(["PORT_STAT", port_info.get("POLL_INTERVAL", DEFLT_1_SEC), port_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if port_drop_info:
-        data.append([PORT_BUFFER_DROP, port_drop_info.get("POLL_INTERVAL", DEFLT_60_SEC), port_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+        data.append([PORT_BUFFER_DROP, port_drop_info.get("POLL_INTERVAL", DEFLT_10_SEC), port_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if rif_info:
         data.append(["RIF_STAT", rif_info.get("POLL_INTERVAL", DEFLT_1_SEC), rif_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if queue_wm_info:

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -49,9 +49,9 @@ class TestCounterpoll(object):
 
     def test_port_buffer_drop_interval_too_short(self):
         runner = CliRunner()
-        result = runner.invoke(counterpoll.cli.commands["port-buffer-drop"].commands["interval"], ["1000"])
+        result = runner.invoke(counterpoll.cli.commands["port-buffer-drop"].commands["interval"], ["100"])
         print(result.output)
-        expected = "Invalid value for \"POLL_INTERVAL\": 1000 is not in the valid range of 30000 to 300000."
+        expected = "Invalid value for \"POLL_INTERVAL\": 100 is not in the valid range of 1000 to 300000."
         assert result.exit_code == 2
         assert expected in result.output
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

