### PR TITLE
Add trap flow counter CLI support

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -476,6 +476,14 @@ def statistics(db):
 def remap_keys(dict):
     return [{'key': k, 'value': v} for k, v in dict.items()]
 
+# ("sonic-clear flowcnt-trap")
+@cli.command()
+def flowcnt_trap():
+    """ Clear trap flow counters """
+    command = "flow_counters_stat -c -t trap"
+    run_command(command)
+
+
 # Load plugins and register them
 helper = util_base.UtilHelper()
 for plugin in helper.load_plugins(plugins):

--- a/scripts/flow_counters_stat
+++ b/scripts/flow_counters_stat
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import _pickle as pickle
+import sys
+
+from natsort import natsorted
+from tabulate import tabulate
+
+# mock the redis for unit test purposes #
+try:
+    if os.environ["UTILITIES_UNIT_TESTING"] == "2":
+        modules_path = os.path.join(os.path.dirname(__file__), "..")
+        tests_path = os.path.join(modules_path, "tests")
+        sys.path.insert(0, modules_path)
+        sys.path.insert(0, tests_path)
+        import mock_tables.dbconnector
+    if os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] == "multi_asic":
+        import mock_tables.mock_multi_asic
+        mock_tables.dbconnector.load_namespace_config()
+           
+except KeyError:
+    pass
+
+import utilities_common.multi_asic as multi_asic_util
+from utilities_common.netstat import format_number_with_comma, table_as_json, ns_diff, format_prate
+
+# Flow counter meta data, new type of flow counters can extend this dictinary to reuse existing logic
+flow_counter_meta = {
+    'trap': {
+        'headers': ['Trap Name', 'Packets', 'Bytes', 'PPS'],
+        'name_map': 'COUNTERS_TRAP_NAME_MAP',
+    }
+}
+flow_counters_fields = ['SAI_COUNTER_STAT_PACKETS', 'SAI_COUNTER_STAT_BYTES']
+
+# Only do diff for 'Packets' and 'Bytes'
+diff_column_positions = set([0, 1]) 
+
+FLOW_COUNTER_TABLE_PREFIX = "COUNTERS:"
+RATES_TABLE_PREFIX = 'RATES:'
+PPS_FIELD = 'RX_PPS'
+STATUS_NA = 'N/A'
+
+
+class FlowCounterStats(object):
+    def __init__(self, args):
+        self.db = None
+        self.multi_asic = multi_asic_util.MultiAsic(namespace_option=args.namespace)
+        self.args = args
+        meta_data = flow_counter_meta[args.type]
+        self.name_map = meta_data['name_map']
+        self.headers = meta_data['headers']
+        self.data_file = os.path.join('/tmp/{}-stats-{}'.format(args.type, os.getuid()))
+        if self.args.delete and os.path.exists(self.data_file):
+            os.remove(self.data_file)
+        self.data = {}
+
+    def show(self):
+        """Show flow counter statistic
+        """
+        self._collect()
+        old_data = self._load()
+        self._diff(old_data, self.data)
+        
+        table = []
+        if self.multi_asic.is_multi_asic:
+            # On multi ASIC platform, an extra column "ASIC ID" must be present to avoid duplicate entry name
+            headers = ['ASIC ID'] + self.headers
+            for ns, stats in natsorted(self.data.items()):
+                for name, values in natsorted(stats.items()):
+                    row = [ns, name, format_number_with_comma(values[0]), format_number_with_comma(values[1]), format_prate(values[2])]
+                    table.append(row)
+        else:
+            headers = self.headers
+            for ns, stats in natsorted(self.data.items()):
+                for name, values in natsorted(stats.items()):
+                    row = [name, format_number_with_comma(values[0]), format_number_with_comma(values[1]), format_prate(values[2])]
+                    table.append(row)
+        if self.args.json:
+            print(table_as_json(table, headers))
+        else:
+            print(tabulate(table, headers, tablefmt='simple', stralign='right'))
+
+    def clear(self):
+        """Clear flow counter statistic. This function does not clear data from ASIC. Instead, it saves flow counter statistic to a file. When user
+           issue show command after clear, it does a diff between new data and saved data.  
+        """
+        self._collect()
+        self._save()
+        print('Flow Counters were successfully cleared')
+
+    @multi_asic_util.run_on_multi_asic
+    def _collect(self):
+        """Collect flow counter statistic from DB. This function is called on a multi ASIC context.
+        """
+        self.data.update(self._get_stats_from_db())
+
+    def _get_stats_from_db(self):
+        """Get flow counter statistic from DB.
+
+        Returns:
+            dict: A dictionary. E.g: {<namespace>: {<trap_name>: [<value_in_pkts>, <value_in_bytes>, <rx_pps>]}}
+        """
+        ns = self.multi_asic.current_namespace
+        name_map = self.db.get_all(self.db.COUNTERS_DB, self.name_map)
+        data = {ns: {}}
+        if not name_map:
+            return data
+
+        for name, counter_oid in name_map.items():
+            values = []
+            full_table_id = FLOW_COUNTER_TABLE_PREFIX + counter_oid
+            for field in flow_counters_fields:
+                counter_data =  self.db.get(self.db.COUNTERS_DB, full_table_id, field)
+                values.append(STATUS_NA if counter_data is None else counter_data)
+
+            full_table_id = RATES_TABLE_PREFIX + counter_oid
+            counter_data =  self.db.get(self.db.COUNTERS_DB, full_table_id, PPS_FIELD)
+            values.append(STATUS_NA if counter_data is None else counter_data)
+            values.append(counter_oid)
+            data[ns][name] = values
+        return data
+
+    def _save(self):
+        """Save flow counter statistic to a file
+        """
+        try:
+            if os.path.exists(self.data_file):
+                os.remove(self.data_file)
+
+            with open(self.data_file, 'wb') as f: 
+                pickle.dump(self.data, f)
+        except IOError as e:
+            print('Failed to save statistic - {}'.format(repr(e)))
+
+    def _load(self):
+        """Load flow counter statistic from a file
+
+        Returns:
+            dict: A dictionary. E.g: {<namespace>: {<trap_name>: [<value_in_pkts>, <value_in_bytes>, <rx_pps>]}}
+        """
+        if not os.path.exists(self.data_file):
+            return None
+
+        try:
+            with open(self.data_file, 'rb') as f:
+                data = pickle.load(f)
+        except IOError as e:
+            print('Failed to load statistic - {}'.format(repr(e)))
+            return None
+        
+        return data
+
+    def _diff(self, old_data, new_data):
+        """Do a diff between new data and old data. 
+
+        Args:
+            old_data (dict): E.g: {<namespace>: {<trap_name>: [<value_in_pkts>, <value_in_bytes>, <rx_pps>]}}
+            new_data (dict): E.g: {<namespace>: {<trap_name>: [<value_in_pkts>, <value_in_bytes>, <rx_pps>]}}
+        """
+        if not old_data:
+            return
+
+        for ns, stats in new_data.items():
+            if ns not in old_data:
+                continue
+            old_stats = old_data[ns]
+            for name, values in stats.items():
+                if name not in old_stats:
+                    continue
+
+                old_values = old_stats[name]
+                if values[-1] != old_values[-1]:
+                    # Counter OID not equal means the trap was removed and added again. Removing a trap would cause
+                    # the stats value restart from 0. To avoid get minus value here, it should not do diff in case
+                    # counter OID is changed.
+                    continue
+
+                for i in diff_column_positions:
+                    values[i] = ns_diff(values[i], old_values[i])
+
+
+def main():
+    parser  = argparse.ArgumentParser(description='Display the flow counters',
+                                    formatter_class=argparse.RawTextHelpFormatter,
+                                    epilog="""
+Examples:
+  flow_counters_stat -c -t trap
+  flow_counters_stat -t trap
+  flow_counters_stat -d -t trap
+""")
+    parser.add_argument('-c', '--clear', action='store_true', help='Copy & clear stats')
+    parser.add_argument('-d', '--delete', action='store_true', help='Delete saved stats')
+    parser.add_argument('-j', '--json', action='store_true', help='Display in JSON format')
+    parser.add_argument('-n','--namespace', default=None, help='Display flow counters for specific namespace')
+    parser.add_argument('-t', '--type', required=True, choices=['trap'],help='Flow counters type')
+
+    args = parser.parse_args()
+
+    stats = FlowCounterStats(args)
+    if args.clear:
+        stats.clear()
+    else:
+        stats.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
         'scripts/fast-reboot-dump.py',
         'scripts/fdbclear',
         'scripts/fdbshow',
+        'scripts/flow_counters_stat',
         'scripts/gearboxutil',
         'scripts/generate_dump',
         'scripts/generate_shutdown_order.py',

--- a/show/flow_counters.py
+++ b/show/flow_counters.py
@@ -1,0 +1,22 @@
+import click
+import utilities_common.cli as clicommon
+import utilities_common.multi_asic as multi_asic_util
+
+#
+# 'flowcnt-trap' group ###
+#
+
+@click.group(cls=clicommon.AliasedGroup)
+def flowcnt_trap():
+    """Show trap flow counter related information"""
+    pass
+
+@flowcnt_trap.command()
+@click.option('--verbose', is_flag=True, help="Enable verbose output")
+@click.option('--namespace', '-n', 'namespace', default=None, type=click.Choice(multi_asic_util.multi_asic_ns_choices()), show_default=True, help='Namespace name or all')
+def stats(verbose, namespace):
+    """Show trap flow counter statistic"""
+    cmd = "flow_counters_stat -t trap"
+    if namespace is not None:
+        cmd += " -n {}".format(namespace)
+    clicommon.run_command(cmd, display_cmd=verbose)

--- a/show/main.py
+++ b/show/main.py
@@ -40,6 +40,7 @@ from . import chassis_modules
 from . import dropcounters
 from . import feature
 from . import fgnhg
+from . import flow_counters
 from . import gearbox
 from . import interfaces
 from . import kdump
@@ -179,6 +180,7 @@ cli.add_command(chassis_modules.chassis)
 cli.add_command(dropcounters.dropcounters)
 cli.add_command(feature.feature)
 cli.add_command(fgnhg.fgnhg)
+cli.add_command(flow_counters.flowcnt_trap)
 cli.add_command(kdump.kdump)
 cli.add_command(interfaces.interfaces)
 cli.add_command(kdump.kdump)

--- a/tests/counterpoll_input/config_db.json
+++ b/tests/counterpoll_input/config_db.json
@@ -784,6 +784,9 @@
         }, 
         "PORT": {
             "FLEX_COUNTER_STATUS": "enable"
+        },
+        "FLOW_CNT_TRAP": {
+            "FLEX_COUNTER_STATUS": "enable"
         }
     }, 
     "PORT": {

--- a/tests/counterpoll_test.py
+++ b/tests/counterpoll_test.py
@@ -3,7 +3,6 @@ import json
 import os
 import pytest
 import sys
-import time
 from click.testing import CliRunner
 from shutil import copyfile
 from utilities_common.db import Db
@@ -26,6 +25,7 @@ PORT_BUFFER_DROP                   60000  enable
 QUEUE_WATERMARK_STAT               10000  enable
 PG_WATERMARK_STAT                  10000  enable
 PG_DROP_STAT                       10000  enable
+FLOW_CNT_TRAP_STAT                  1000  enable
 """
 
 class TestCounterpoll(object):
@@ -108,6 +108,42 @@ class TestCounterpoll(object):
 
         table = db.cfgdb.get_table('FLEX_COUNTER_TABLE')
         assert test_interval == table["PG_DROP"]["POLL_INTERVAL"]
+
+    @pytest.mark.parametrize("status", ["disable", "enable"])
+    def test_update_trap_counter_status(self, status):
+        runner = CliRunner()
+        db = Db()
+
+        result = runner.invoke(counterpoll.cli.commands["flowcnt-trap"].commands[status], [], obj=db.cfgdb)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        table = db.cfgdb.get_table('FLEX_COUNTER_TABLE')
+        assert status == table["FLOW_CNT_TRAP"]["FLEX_COUNTER_STATUS"]
+
+    def test_update_trap_counter_interval(self):
+        runner = CliRunner()
+        db = Db()
+        test_interval = "20000"
+
+        result = runner.invoke(counterpoll.cli.commands["flowcnt-trap"].commands["interval"], [test_interval], obj=db.cfgdb)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        table = db.cfgdb.get_table('FLEX_COUNTER_TABLE')
+        assert test_interval == table["FLOW_CNT_TRAP"]["POLL_INTERVAL"]
+
+        test_interval = "500"
+        result = runner.invoke(counterpoll.cli.commands["flowcnt-trap"].commands["interval"], [test_interval], obj=db.cfgdb)
+        expected = "Invalid value for \"POLL_INTERVAL\": 500 is not in the valid range of 1000 to 30000."
+        assert result.exit_code == 2
+        assert expected in result.output
+
+        test_interval = "40000"
+        result = runner.invoke(counterpoll.cli.commands["flowcnt-trap"].commands["interval"], [test_interval], obj=db.cfgdb)
+        expected = "Invalid value for \"POLL_INTERVAL\": 40000 is not in the valid range of 1000 to 30000."
+        assert result.exit_code == 2
+        assert expected in result.output
 
     @classmethod
     def teardown_class(cls):

--- a/tests/flow_counter_stats_test.py
+++ b/tests/flow_counter_stats_test.py
@@ -1,0 +1,173 @@
+import importlib
+import os
+
+from click.testing import CliRunner
+
+import show.main as show
+import clear.main as clear
+
+from .utils import get_result_and_return_code
+
+test_path = os.path.dirname(os.path.abspath(__file__))
+modules_path = os.path.dirname(test_path)
+scripts_path = os.path.join(modules_path, "scripts")
+
+
+expect_show_output = """\
+  Trap Name    Packets    Bytes      PPS
+-----------  ---------  -------  -------
+       dhcp        100    2,000  50.25/s
+"""
+
+expect_show_output_json = """\
+{
+    "dhcp": {
+        "Bytes": "2,000",
+        "PPS": "50.25/s",
+        "Packets": "100"
+    }
+}
+"""
+
+expect_show_output_after_clear = """\
+  Trap Name    Packets    Bytes      PPS
+-----------  ---------  -------  -------
+       dhcp          0        0  50.25/s
+"""
+
+expect_show_output_multi_asic = """\
+  ASIC ID    Trap Name    Packets    Bytes      PPS
+---------  -----------  ---------  -------  -------
+    asic0         dhcp        100    2,000  50.25/s
+    asic1         dhcp        200    3,000  45.25/s
+"""
+
+expect_show_output_json_multi_asic = """\
+{
+    "asic0": {
+        "Bytes": "2,000",
+        "PPS": "50.25/s",
+        "Packets": "100",
+        "Trap Name": "dhcp"
+    },
+    "asic1": {
+        "Bytes": "3,000",
+        "PPS": "45.25/s",
+        "Packets": "200",
+        "Trap Name": "dhcp"
+    }
+}
+"""
+
+expect_show_output_multi_asic_after_clear = """\
+  ASIC ID    Trap Name    Packets    Bytes      PPS
+---------  -----------  ---------  -------  -------
+    asic0         dhcp          0        0  50.25/s
+    asic1         dhcp          0        0  45.25/s
+"""
+
+
+def delete_cache():
+    cmd = 'flow_counters_stat -t trap -d'
+    get_result_and_return_code(cmd)
+
+
+class TestTrapStat:
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ["UTILITIES_UNIT_TESTING"] = "2"
+        delete_cache()
+
+    def test_show(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["flowcnt-trap"].commands["stats"],
+            []
+        )
+        print(result.output)
+
+        assert result.exit_code == 0
+        assert result.output == expect_show_output
+
+    def test_show_json(self):
+        cmd = 'flow_counters_stat -t trap -j'
+        return_code, result = get_result_and_return_code(cmd)
+        assert return_code == 0
+        assert result == expect_show_output_json
+
+    def test_clear(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            clear.cli.commands["flowcnt-trap"],
+            []
+        )
+        print(result.output)
+
+        assert result.exit_code == 0
+
+        result = runner.invoke(
+            show.cli.commands["flowcnt-trap"].commands["stats"],
+            []
+        )
+        print(result.output)
+
+        assert result.exit_code == 0
+        assert result.output == expect_show_output_after_clear
+
+
+class TestTrapStatsMultiAsic:
+    @classmethod
+    def setup_class(cls):
+        print("SETUP")
+        os.environ["PATH"] += os.pathsep + scripts_path
+        os.environ["UTILITIES_UNIT_TESTING"] = "2"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = "multi_asic"
+        delete_cache()
+
+    @classmethod
+    def teardown_class(cls):
+        print("TEARDOWN")
+        os.environ["PATH"] = os.pathsep.join(
+            os.environ["PATH"].split(os.pathsep)[:-1]
+        )
+        os.environ["UTILITIES_UNIT_TESTING"] = "0"
+        os.environ["UTILITIES_UNIT_TESTING_TOPOLOGY"] = ""
+        delete_cache()
+        import mock_tables.mock_single_asic
+        importlib.reload(mock_tables.mock_single_asic)
+
+    def test_show(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["flowcnt-trap"].commands["stats"],
+            []
+        )
+        print(result.output)
+
+        assert result.exit_code == 0
+        assert result.output == expect_show_output_multi_asic
+
+    def test_show_json(self):
+        cmd = 'flow_counters_stat -t trap -j'
+        return_code, result = get_result_and_return_code(cmd)
+        assert return_code == 0
+        assert result == expect_show_output_json_multi_asic
+
+    def test_clear(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            clear.cli.commands["flowcnt-trap"],
+            []
+        )
+        print(result.output)
+
+        result = runner.invoke(
+            show.cli.commands["flowcnt-trap"].commands["stats"],
+            []
+        )
+        print(result.output)
+
+        assert result.exit_code == 0
+        assert result.output == expect_show_output_multi_asic_after_clear

--- a/tests/mock_tables/asic0/counters_db.json
+++ b/tests/mock_tables/asic0/counters_db.json
@@ -1788,5 +1788,15 @@
         "crm_stats_acl_entry_used":"0",
         "crm_stats_acl_counter_available":"1280",
         "crm_stats_acl_entry_available":"1024"
+    },
+    "COUNTERS_TRAP_NAME_MAP":{
+        "dhcp": "oid:0x1500000000034e"
+    },
+    "COUNTERS:oid:0x1500000000034e":{
+        "SAI_COUNTER_STAT_PACKETS": 100,
+        "SAI_COUNTER_STAT_BYTES": 2000
+    },
+    "RATES:oid:0x1500000000034e":{
+        "RX_PPS": 50.25
     }
 }

--- a/tests/mock_tables/asic1/counters_db.json
+++ b/tests/mock_tables/asic1/counters_db.json
@@ -983,5 +983,15 @@
         "crm_stats_acl_entry_used":"0",
         "crm_stats_acl_counter_available":"1280",
         "crm_stats_acl_entry_available":"1024"
+    },
+    "COUNTERS_TRAP_NAME_MAP":{
+        "dhcp": "oid:0x1500000000034e"
+    },
+    "COUNTERS:oid:0x1500000000034e":{
+        "SAI_COUNTER_STAT_PACKETS": 200,
+        "SAI_COUNTER_STAT_BYTES": 3000
+    },
+    "RATES:oid:0x1500000000034e":{
+        "RX_PPS": 45.25
     }
 }

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -1553,6 +1553,10 @@
         "POLL_INTERVAL": "10000",
         "FLEX_COUNTER_STATUS": "enable"
     },
+    "FLEX_COUNTER_TABLE|FLOW_CNT_TRAP": {
+        "POLL_INTERVAL": "1000",
+        "FLEX_COUNTER_STATUS": "enable"
+    },
     "PFC_WD|Ethernet0": {
         "action": "drop",
         "detection_time": "600",

--- a/tests/mock_tables/counters_db.json
+++ b/tests/mock_tables/counters_db.json
@@ -1951,5 +1951,15 @@
         "crm_stats_acl_entry_used":"0",
         "crm_stats_acl_counter_available":"1280",
         "crm_stats_acl_entry_available":"1024"
+    },
+    "COUNTERS_TRAP_NAME_MAP":{
+        "dhcp": "oid:0x1500000000034e"
+    },
+    "COUNTERS:oid:0x1500000000034e":{
+        "SAI_COUNTER_STAT_PACKETS": 100,
+        "SAI_COUNTER_STAT_BYTES": 2000
+    },
+    "RATES:oid:0x1500000000034e":{
+        "RX_PPS": 50.25
     }
 }


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add trap flow counter CLI support. See HLD: https://github.com/Azure/SONiC/pull/858

#### How I did it

Add new command:

- counterpoll flowcnt-trap enable/disable
- counterpoll flowcnt-trap interval
- show flowcnt-trap stats
- sonic-clear flowcnt-trap
- Extend command: counterpoll show

#### How to verify it

Unit test/Manual test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

