### PR TITLE
[config] Allow user to set none value for interface type

### DIFF
--- a/scripts/portconfig
+++ b/scripts/portconfig
@@ -63,7 +63,7 @@ PORT_STATE_SUPPORTED_SPEEDS = "supported_speeds"
 VALID_INTERFACE_TYPE_SET = set(['CR','CR2','CR4','SR','SR2','SR4',
                                 'LR','LR4','KR','KR4','CAUI','GMII',
                                 'SFI','XLAUI','KR2','CAUI4','XAUI',
-                                'XFI','XGMII'])
+                                'XFI','XGMII', 'none'])
 
 class portconfig(object):
     """
@@ -166,7 +166,7 @@ class portconfig(object):
     def set_adv_interface_types(self, port, adv_interface_types):
         if self.verbose:
             print("Setting adv_interface_types %s on port %s" % (adv_interface_types, port))
-        
+
         if adv_interface_types != 'all':
             config_interface_type_list = [x.strip() for x in adv_interface_types.split(',')]
             config_interface_types = set(config_interface_type_list)
@@ -179,7 +179,7 @@ class portconfig(object):
                 print("Valid interface types:{}".format(','.join(VALID_INTERFACE_TYPE_SET)))
                 exit(1)
         self.db.mod_entry(PORT_TABLE_NAME, port, {PORT_ADV_INTERFACE_TYPES_CONFIG_FIELD_NAME: adv_interface_types})
-    
+
     def get_supported_speeds(self, port):
         if not self.namespace:
             state_db = SonicV2Connector(host="127.0.0.1")

--- a/tests/config_an_test.py
+++ b/tests/config_an_test.py
@@ -17,7 +17,7 @@ sys.path.insert(0, modules_path)
 @pytest.fixture(scope='module')
 def ctx(scope='module'):
     db = Db()
-    obj = {'config_db':db.cfgdb, 'namespace': ''}  
+    obj = {'config_db':db.cfgdb, 'namespace': ''}
     yield obj
 
 
@@ -56,6 +56,7 @@ class TestConfigInterface(object):
 
     def test_config_type(self, ctx):
         self.basic_check("type", ["Ethernet0", "CR4"], ctx)
+        self.basic_check("type", ["Ethernet0", "none"], ctx)
         self.basic_check("type", ["Invalid", "CR4"], ctx, operator.ne)
         self.basic_check("type", ["Ethernet0", ""], ctx, operator.ne)
         result = self.basic_check("type", ["Ethernet0", "Invalid"], ctx, operator.ne)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Allow user to set none value for interface type

**Why I did it**

Say user has speed=50G, interface_type=CR2, and user wants to change it to 10G and CR. Currently, there is no CLI can support it, because:

1. If you change the interface type to CR first, SAI will get 50G and CR, SAI will report error because not supported
2. If you change the speed to 10G first, SAI will get 10G and CR2, also not supported

The only way for now is to manually change the CONFIG_DB and do a config reload, this is not user friendly.

This PR allow user to set none value to interface type. So there is a way to achieve the goal via CLI:

1. config interface type XXX none
2. config interface speed XXX 10000
3. config interface type XXX CR

**How I verified it**

Manual test
New unit test case

**Details if related**
