### PR TITLE
[flow counter] Fix issue: should not compare str with int

### DIFF
--- a/scripts/flow_counters_stat
+++ b/scripts/flow_counters_stat
@@ -230,7 +230,7 @@ class FlowCounterStats(object):
                     # counter OID is changed.
                     old_values[-1] = values[-1]
                     for i in diff_column_positions:
-                        old_values[i] = 0
+                        old_values[i] = '0'
                         values[i] = ns_diff(values[i], old_values[i])
                     need_update_cache = True
                     continue
@@ -238,13 +238,13 @@ class FlowCounterStats(object):
                 has_negative_diff = False
                 for i in diff_column_positions:
                     # If any diff has negative value, set all counter values to 0 and update cache
-                    if values[i] < old_values[i]:
+                    if int(values[i]) < int(old_values[i]):
                         has_negative_diff = True
                         break
 
                 if has_negative_diff:
                     for i in diff_column_positions:
-                        old_values[i] = 0
+                        old_values[i] = '0'
                         values[i] = ns_diff(values[i], old_values[i])
                     need_update_cache = True
                     continue

--- a/tests/flow_counter_stats_test.py
+++ b/tests/flow_counter_stats_test.py
@@ -132,25 +132,25 @@ class TestTrapStat:
         stats._collect = mock.MagicMock()
         old_data = {
             '': {
-                'bgp': [100, 200, 50.0, 1],
-                'bgpv6': [100, 200, 50.0, 2],
-                'lldp': [100, 200, 50.0, 3],
+                'bgp': ['100', '200', '50.0', '1'],
+                'bgpv6': ['100', '200', '50.0', '2'],
+                'lldp': ['100', '200', '50.0', '3'],
             }
         }
         stats._save(old_data)
         stats.data = {
             '': {
-                'bgp': [100, 200, 50.0, 4],
-                'bgpv6': [100, 100, 50.0, 2],
-                'lldp': [200, 300, 50.0, 3],
+                'bgp': ['100', '200', '50.0', '4'],
+                'bgpv6': ['100', '100', '50.0', '2'],
+                'lldp': ['200', '300', '50.0', '3'],
             }
         }
 
         stats._collect_and_diff()
         cached_data = stats._load()
-        assert cached_data['']['bgp'] == [0, 0, 50.0, 4]
-        assert cached_data['']['bgpv6'] == [0, 0, 50.0, 2]
-        assert cached_data['']['lldp'] == [100, 200, 50.0, 3]
+        assert cached_data['']['bgp'] == ['0', '0', '50.0', '4']
+        assert cached_data['']['bgpv6'] == ['0', '0', '50.0', '2']
+        assert cached_data['']['lldp'] == ['100', '200', '50.0', '3']
 
 
 class TestTrapStatsMultiAsic:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

When clearing stats, current flow counter stats is serialized to a file for further compare. All stats value is saved as string value. When doing diff, the loaded stats value shall be convert into int and do the compare. The PR is to fix this issue.

#### How I did it

1. Convert value to int when doing compare
2. Save value as string to the dump file

#### How to verify it

1. Adjust unit test case to cover the change

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

