### PR TITLE
[db_migrator.py] Fix issue while upgrading from 202205 to 202211 via fast reboot

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -658,7 +658,7 @@ class DBMigrator():
         # overwrite the routing-config-mode as per minigraph parser
         # Criteria for update:
         # if config mode is missing in base OS or if base and target modes are not same
-        #  Eg. in 201811 mode is "unified", and in newer branches mode is "separated" 
+        #  Eg. in 201811 mode is "unified", and in newer branches mode is "separated"
         if ('docker_routing_config_mode' not in device_metadata_old and 'docker_routing_config_mode' in device_metadata_new) or \
         (device_metadata_old.get('docker_routing_config_mode') != device_metadata_new.get('docker_routing_config_mode')):
             device_metadata_old['docker_routing_config_mode'] = device_metadata_new.get('docker_routing_config_mode')
@@ -1000,12 +1000,14 @@ class DBMigrator():
         # reading FAST_REBOOT table can't be done with stateDB.get as it uses hget behind the scenes and the table structure is
         # not using hash and won't work.
         # FAST_REBOOT table exists only if fast-reboot was triggered.
-        keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT|system")
-        if keys:
-            enable_state = 'true'
-        else:
-            enable_state = 'false'
-        self.stateDB.set(self.stateDB.STATE_DB, 'FAST_RESTART_ENABLE_TABLE|system', 'enable', enable_state)
+        keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_RESTART_ENABLE_TABLE|system")
+        if not keys:
+            keys = self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT|system")
+            if keys:
+                enable_state = 'true'
+            else:
+                enable_state = 'false'
+            self.stateDB.set(self.stateDB.STATE_DB, 'FAST_RESTART_ENABLE_TABLE|system', 'enable', enable_state)
         self.set_version('version_4_0_1')
         return 'version_4_0_1'
 
@@ -1024,8 +1026,8 @@ class DBMigrator():
         Version 4_0_2.
         """
         log.log_info('Handling version_4_0_2')
-
-        if self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT|system"):
+        enable_state = self.stateDB.get(self.stateDB.STATE_DB, 'FAST_RESTART_ENABLE_TABLE|system', 'enable')
+        if self.stateDB.keys(self.stateDB.STATE_DB, "FAST_REBOOT|system") or enable_state == 'true':
             self.migrate_config_db_flex_counter_delay_status()
 
         self.set_version('version_4_0_3')

--- a/tests/db_migrator_input/state_db/fast_reboot_upgrade_from_202205.json
+++ b/tests/db_migrator_input/state_db/fast_reboot_upgrade_from_202205.json
@@ -1,0 +1,5 @@
+{
+	"FAST_RESTART_ENABLE_TABLE|system": {
+		"enable": "true"
+	}
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -721,3 +721,11 @@ class TestFastUpgrade_to_4_0_3(object):
         advance_version_for_expected_database(dbmgtr.configDB, expected_db.cfgdb, 'version_4_0_3')
         assert not self.check_config_db(dbmgtr.configDB, expected_db.cfgdb)
         assert dbmgtr.CURRENT_VERSION == expected_db.cfgdb.get_entry('VERSIONS', 'DATABASE')['VERSION']
+
+
+class TestFastUpgrade_to_4_0_3_from_202205(TestFastUpgrade_to_4_0_3):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = "2"
+        cls.config_db_tables_to_verify = ['FLEX_COUNTER_TABLE']
+        dbconnector.dedicated_dbs['STATE_DB'] = os.path.join(mock_db_path, 'state_db', 'fast_reboot_upgrade_from_202205')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Fix issue while upgrading from 202205 to 202211 via fast reboot. This issue is caused by a mismatch version handling for fast reboot in db_migrator. 

In 202205, the db migrator for fast reboot flag handling is 3_0_5:

https://github.com/sonic-net/sonic-utilities/blob/56a1ae24dc8f4e2dd2ad8929506ecdc836d3dd7c/scripts/db_migrator.py#L920

However, in master(202211), the db migrator for fast reboot flag handling is 4_0_0:

https://github.com/sonic-net/sonic-utilities/blob/7435b1ca539382e644f29d424c551f6258fd2920/scripts/db_migrator.py#L993


This mismatch causes an incorrect sequence like this:

```
1. User issue fast-reboot under 202205
2. fast-reboot script set fast reboot flag by command "sonic-db-cli STATE_DB HSET "FAST_RESTART_ENABLE_TABLE|system" "enable" "true" &>/dev/null"
3. system boot to 202211
4. db_migrator found the database version is 3_0_6, it will run 4_0_0, however, it found FAST_REBOOT|system does not exist, and it set  FAST_RESTART_ENABLE_TABLE|system enable to false
5. system incorrectly performs cold reboot
```

#### How I did it

in db migrator if we see there is FAST_RESTART_ENABLE_TABLE already, we should skip fast reboot flag migration

#### How to verify it

unit test
manual test

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

