### PR TITLE
[202311] Add multi ASIC support for syslog rate limit feature

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -10096,7 +10096,7 @@ This command displays rate limit configuration for containers.
 
 - Usage
   ```
-  show syslog rate-limit-container [<service_name>]
+  show syslog rate-limit-container [<service_name>] -n [<namespace>]
   ```
 
 - Example:
@@ -10120,6 +10120,37 @@ This command displays rate limit configuration for containers.
   SERVICE         INTERVAL    BURST
   --------------  ----------  -------
   bgp             0           0
+
+  # Multi ASIC
+  show syslog rate-limit-container
+  SERVICE    INTERVAL     BURST
+  --------   ----------   --------
+  bgp        500          N/A
+  snmp       300          20000
+  swss       2000         12000
+  Namespace asic0:
+  SERVICE    INTERVAL     BURST
+  --------   ----------   --------
+  bgp        500          N/A
+  snmp       300          20000
+  swss       2000         12000
+
+  # Multi ASIC
+  show syslog rate-limit-container bgp
+  SERVICE    INTERVAL     BURST
+  --------   ----------   --------
+  bgp        500          5000
+  Namespace asic0:
+  SERVICE    INTERVAL     BURST
+  --------   ----------   --------
+  bgp        500          5000
+
+  # Multi ASIC
+  show syslog rate-limit-container bgp -n asic1
+  Namespace asic1:
+  SERVICE    INTERVAL     BURST
+  --------   ----------   --------
+  bgp        500          5000
   ```
 
 ### Syslog Config Commands
@@ -10198,10 +10229,19 @@ This command is used to configure syslog rate limit for containers.
 - Parameters:
   - _interval_: determines the amount of time that is being measured for rate limiting.
   - _burst_: defines the amount of messages, that have to occur in the time limit of interval, to trigger rate limiting
+  - _namespace_: namespace name or all. Value "default" indicates global namespace.
 
 - Example:
   ```
+  # Config bgp for all namespaces. For multi ASIC platforms, bgp service in all namespaces will be affected.
+  # For single ASIC platforms, bgp service in global namespace will be affected.
   admin@sonic:~$ sudo config syslog rate-limit-container bgp --interval 300 --burst 20000
+
+  # Config bgp for global namespace only.
+  config syslog rate-limit-container bgp --interval 300 --burst 20000 -n default
+
+  # Config bgp for asic0 namespace only.
+  config syslog rate-limit-container bgp --interval 300 --burst 20000 -n asic0
   ```
 
 **config syslog rate-limit-feature enable**
@@ -10210,12 +10250,28 @@ This command is used to enable syslog rate limit feature.
 
 - Usage:
   ```
-  config syslog rate-limit-feature enable
+  config syslog rate-limit-feature enable [<service_name>] -n [<namespace>]
   ```
 
 - Example:
   ```
+  # Enable syslog rate limit for all services in all namespaces
   admin@sonic:~$ sudo config syslog rate-limit-feature enable
+
+  # Enable syslog rate limit for all services in global namespace
+  config syslog rate-limit-feature enable -n default
+
+  # Enable syslog rate limit for all services in asic0 namespace
+  config syslog rate-limit-feature enable -n asic0
+
+  # Enable syslog rate limit for database in all namespaces
+  config syslog rate-limit-feature enable database
+
+  # Enable syslog rate limit for database in default namespace
+  config syslog rate-limit-feature enable database -n default
+
+  # Enable syslog rate limit for database in asci0 namespace
+  config syslog rate-limit-feature enable database -n asci0
   ```
 
 **config syslog rate-limit-feature disable**
@@ -10224,12 +10280,28 @@ This command is used to disable syslog rate limit feature.
 
 - Usage:
   ```
-  config syslog rate-limit-feature disable
+  config syslog rate-limit-feature disable [<service_name>] -n [<namespace>]
   ```
 
 - Example:
   ```
+  # Disable syslog rate limit for all services in all namespaces
   admin@sonic:~$ sudo config syslog rate-limit-feature disable
+
+  # Disable syslog rate limit for all services in global namespace
+  config syslog rate-limit-feature disable -n default
+
+  # Disable syslog rate limit for all services in asic0 namespace
+  config syslog rate-limit-feature disable -n asic0
+
+  # Disable syslog rate limit for database in all namespaces
+  config syslog rate-limit-feature disable database
+
+  # Disable syslog rate limit for database in default namespace
+  config syslog rate-limit-feature disable database -n default
+
+  # Disable syslog rate limit for database in asci0 namespace
+  config syslog rate-limit-feature disable database -n asci0
   ```
 
 Go Back To [Beginning of the document](#) or [Beginning of this section](#syslog)

--- a/show/syslog.py
+++ b/show/syslog.py
@@ -1,9 +1,12 @@
+from unicodedata import name
 import click
 
 import tabulate
 from natsort import natsorted
 
 import utilities_common.cli as clicommon
+import utilities_common.multi_asic as multi_asic_util
+from sonic_py_common import multi_asic
 from syslog_util import common as syslog_common
 
 
@@ -83,8 +86,11 @@ def rate_limit_host(db):
     name='rate-limit-container'
 )
 @click.argument('service_name', metavar='<service_name>', required=False)
+@click.option('--namespace', '-n', 'namespace', default=None, 
+              type=click.Choice(multi_asic_util.multi_asic_ns_choices() + ['default']), 
+              show_default=True, help='Namespace name or all')
 @clicommon.pass_db
-def rate_limit_container(db, service_name):
+def rate_limit_container(db, service_name, namespace):
     """ Show syslog rate limit configuration for containers """
 
     header = [
@@ -92,16 +98,57 @@ def rate_limit_container(db, service_name):
         "INTERVAL",
         "BURST",
     ]
-    body = []
+    
+    # Feature configuration in global DB
     features = db.cfgdb.get_table(syslog_common.FEATURE_TABLE)
+    if service_name:
+        syslog_common.service_validator(features, service_name)
+        
+    global_feature_data, per_ns_feature_data = syslog_common.extract_feature_data(features)
+    if not namespace:
+        # for all namespaces
+        is_first = True
+        for namespace, cfg_db in natsorted(db.cfgdb_clients.items()):
+            if is_first:
+                is_first = False
+            else:
+                # add a new blank line between each namespace
+                click.echo('\n')
+                
+            if namespace == multi_asic.DEFAULT_NAMESPACE:
+                if service_name and service_name not in global_feature_data:
+                    continue
+                echo_rate_limit_config(header, cfg_db, service_name, global_feature_data)
+            else:
+                if service_name and service_name not in per_ns_feature_data:
+                    continue
+                echo_rate_limit_config(header, cfg_db, service_name, per_ns_feature_data, namespace)
+    elif namespace == 'default':
+        # for default/global namespace only
+        echo_rate_limit_config(header, db.cfgdb, service_name, global_feature_data)
+    else:
+        # for a specific namespace
+        echo_rate_limit_config(header, db.cfgdb_clients[namespace], service_name, per_ns_feature_data, namespace)
+    
 
+def echo_rate_limit_config(header, db, service_name, features, namespace=None):
+    """Echo rate limit configuration
+
+    Args:
+        header (list): CLI headers
+        db (object): Db object
+        service_name (str): Nullable service name to be printed.
+        features (dict): Feature data got from CONFIG DB
+        namespace (str, optional): Namespace provided by user. Defaults to None.
+    """
+    body = []
     if service_name:
         syslog_common.service_validator(features, service_name)
         service_list = [service_name]
     else:
-        service_list = [name for name, service_config in features.items() if service_config.get(syslog_common.SUPPORT_RATE_LIMIT, '').lower() == 'true']
-
-    syslog_configs = db.cfgdb.get_table(syslog_common.SYSLOG_CONFIG_FEATURE_TABLE)
+        service_list = features.keys()
+    
+    syslog_configs = db.get_table(syslog_common.SYSLOG_CONFIG_FEATURE_TABLE)
     for service in natsorted(service_list):
         if service in syslog_configs:
             entry = syslog_configs[service]
@@ -110,5 +157,11 @@ def rate_limit_container(db, service_name):
                         entry.get(syslog_common.SYSLOG_RATE_LIMIT_BURST, 'N/A')])
         else:
             body.append([service, 'N/A', 'N/A'])
-
-    click.echo(format(header, body))
+    
+    if namespace:
+        click.echo(f'Namespace {namespace}:')
+    
+    if body:
+        click.echo(format(header, body))
+    else:
+        click.echo('N/A')

--- a/tests/mock_tables/asic0/config_db.json
+++ b/tests/mock_tables/asic0/config_db.json
@@ -287,5 +287,20 @@
         "ports@": "Ethernet124",
         "type": "L3",
         "stage": "ingress"
+    },
+    "FABRIC_MONITOR|FABRIC_MONITOR_DATA": {
+        "monCapacityThreshWarn": "100",
+        "monErrThreshCrcCells": "1",
+        "monErrThreshRxCells": "61035156",
+        "monPollThreshIsolation": "1",
+        "monPollThreshRecovery": "8"
+    },
+    "SYSLOG_CONFIG_FEATURE|bgp": {
+        "rate_limit_interval": "111",
+        "rate_limit_burst": "33333"
+    },
+    "SYSLOG_CONFIG_FEATURE|database": {
+        "rate_limit_interval": "222",
+        "rate_limit_burst": "22222"
     }
 }

--- a/tests/mock_tables/asic1/config_db.json
+++ b/tests/mock_tables/asic1/config_db.json
@@ -227,5 +227,20 @@
         "holdtime": "10",
         "asn": "65200",
         "keepalive": "3"
+    },
+    "FABRIC_MONITOR|FABRIC_MONITOR_DATA": {
+        "monCapacityThreshWarn": "100",
+        "monErrThreshCrcCells": "1",
+        "monErrThreshRxCells": "61035156",
+        "monPollThreshIsolation": "1",
+        "monPollThreshRecovery": "8"
+    },
+    "SYSLOG_CONFIG_FEATURE|bgp": {
+        "rate_limit_interval": "444",
+        "rate_limit_burst": "44444"
+    },
+    "SYSLOG_CONFIG_FEATURE|database": {
+        "rate_limit_interval": "555",
+        "rate_limit_burst": "55555"
     }
 }

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -793,13 +793,19 @@
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_alert": "disabled",
-        "set_owner": "local"
+        "set_owner": "local",
+        "support_syslog_rate_limit": "true",
+        "has_global_scope": "false",
+        "has_per_asic_scope": "true"
     },
     "FEATURE|database": {
         "state": "always_enabled",
         "auto_restart": "always_enabled",
         "high_mem_alert": "disabled",
-        "set_owner": "local"
+        "set_owner": "local",
+        "support_syslog_rate_limit": "true",
+        "has_global_scope": "true",
+        "has_per_asic_scope": "true"
     },
     "FEATURE|dhcp_relay": {
         "state": "enabled",
@@ -823,7 +829,10 @@
         "state": "enabled",
         "auto_restart": "enabled",
         "high_mem_alert": "disabled",
-        "set_owner": "kube"
+        "set_owner": "kube",
+        "support_syslog_rate_limit": "true",
+        "has_global_scope": "true",
+        "has_per_asic_scope": "false"
     },
     "FEATURE|radv": {
         "state": "enabled",
@@ -872,6 +881,14 @@
         "auto_restart": "enabled",
         "high_mem_alert": "disabled",
         "set_owner": "kube"
+    },
+    "SYSLOG_CONFIG_FEATURE|database": {
+        "rate_limit_interval": "200",
+        "rate_limit_burst": "20000"
+    },
+    "SYSLOG_CONFIG_FEATURE|pmon": {
+        "rate_limit_interval": "100",
+        "rate_limit_burst": "10000"
     },
     "DEVICE_METADATA|localhost": {
         "default_bgp_status": "down",

--- a/tests/syslog_multi_asic_test.py
+++ b/tests/syslog_multi_asic_test.py
@@ -1,0 +1,281 @@
+import mock
+import pytest
+from click.testing import CliRunner
+from importlib import reload
+from utilities_common.db import Db
+
+show_all_config = """SERVICE    INTERVAL    BURST
+---------  ----------  -------
+database   200         20000
+pmon       100         10000
+
+
+Namespace asic0:
+SERVICE    INTERVAL    BURST
+---------  ----------  -------
+bgp        111         33333
+database   222         22222
+
+
+Namespace asic1:
+SERVICE    INTERVAL    BURST
+---------  ----------  -------
+bgp        444         44444
+database   555         55555
+"""
+
+show_global_ns_config = """SERVICE    INTERVAL    BURST
+---------  ----------  -------
+database   200         20000
+pmon       100         10000
+"""
+
+show_asic0_ns_config = """Namespace asic0:
+SERVICE    INTERVAL    BURST
+---------  ----------  -------
+bgp        111         33333
+database   222         22222
+"""
+
+show_all_ns_database_config = """SERVICE    INTERVAL    BURST
+---------  ----------  -------
+database   200         20000
+
+
+Namespace asic0:
+SERVICE    INTERVAL    BURST
+---------  ----------  -------
+database   222         22222
+
+
+Namespace asic1:
+SERVICE    INTERVAL    BURST
+---------  ----------  -------
+database   555         55555
+"""
+
+show_global_ns_database_config = """SERVICE    INTERVAL    BURST
+---------  ----------  -------
+database   200         20000
+"""
+
+show_asic0_ns_database_config = """Namespace asic0:
+SERVICE    INTERVAL    BURST
+---------  ----------  -------
+database   222         22222
+"""
+
+
+@pytest.fixture(scope='module')
+def setup_cmd_module():
+    # Mock to multi ASIC
+    from .mock_tables import mock_multi_asic
+    from .mock_tables import dbconnector
+    reload(mock_multi_asic)
+    dbconnector.load_namespace_config()
+    
+    import show.main as show
+    import config.main as config
+    
+    # Refresh syslog module for show and config
+    import show.syslog as show_syslog
+    reload(show_syslog)
+    show.cli.add_command(show_syslog.syslog)
+    
+    import config.syslog as config_syslog
+    reload(config_syslog)
+    config.config.add_command(config_syslog.syslog)
+    
+    yield show, config
+    
+    # Mock back to single ASIC
+    from .mock_tables import mock_single_asic
+    reload(mock_single_asic)
+    
+    # Refresh syslog module for show and config
+    reload(show_syslog)
+    show.cli.add_command(show_syslog.syslog)
+    
+    reload(config_syslog)
+    config.config.add_command(config_syslog.syslog)
+
+
+class TestSyslogRateLimitMultiAsic:
+    def test_show_rate_limit_container(self, setup_cmd_module):
+        show, _ = setup_cmd_module
+        
+        runner = CliRunner()
+        result = runner.invoke(
+            show.cli.commands["syslog"].commands["rate-limit-container"],
+            []
+        )
+        
+        assert result.output == show_all_config
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            show.cli.commands["syslog"].commands["rate-limit-container"], ["-n", "default"]
+        )
+        
+        assert result.output == show_global_ns_config
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            show.cli.commands["syslog"].commands["rate-limit-container"], ["-n", "asic0"]
+        )
+        
+        assert result.output == show_asic0_ns_config
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            show.cli.commands["syslog"].commands["rate-limit-container"], ["database"]
+        )
+        
+        assert result.output == show_all_ns_database_config
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            show.cli.commands["syslog"].commands["rate-limit-container"], ["database", "-n", "default"]
+        )
+        
+        assert result.output == show_global_ns_database_config
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            show.cli.commands["syslog"].commands["rate-limit-container"], ["database", "-n", "asic0"]
+        )
+        
+        assert result.output == show_asic0_ns_database_config
+        assert result.exit_code == 0
+
+    def test_config_rate_limit_container(self, setup_cmd_module):
+        _, config = setup_cmd_module
+        
+        runner = CliRunner()
+        db = Db()
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-container"],
+            ["database", "--interval", 1, "--burst", 100], obj=db
+        )
+        assert result.exit_code == 0
+        for cfg_db in db.cfgdb_clients.values():
+            data = cfg_db.get_entry('SYSLOG_CONFIG_FEATURE', 'database')
+            assert data['rate_limit_burst'] == '100'
+            assert data['rate_limit_interval'] == '1'
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-container"],
+            ["bgp", "--interval", 1, "--burst", 100], obj=db
+        )
+        assert result.exit_code == 0
+        for namespace, cfg_db in db.cfgdb_clients.items():
+            if namespace != '':
+                data = cfg_db.get_entry('SYSLOG_CONFIG_FEATURE', 'bgp')
+                assert data['rate_limit_burst'] == '100'
+                assert data['rate_limit_interval'] == '1'
+            else:
+                table = cfg_db.get_table('SYSLOG_CONFIG_FEATURE')
+                assert 'bgp' not in table
+                
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-container"],
+            ["pmon", "--interval", 1, "--burst", 100], obj=db
+        )
+        assert result.exit_code == 0
+        for namespace, cfg_db in db.cfgdb_clients.items():
+            if namespace == '':
+                data = cfg_db.get_entry('SYSLOG_CONFIG_FEATURE', 'pmon')
+                assert data['rate_limit_burst'] == '100'
+                assert data['rate_limit_interval'] == '1'
+            else:
+                table = cfg_db.get_table('SYSLOG_CONFIG_FEATURE')
+                assert 'pmon' not in table
+                
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-container"],
+            ["pmon", "--interval", 2, "--burst", 200, "-n", "default"], obj=db
+        )
+        assert result.exit_code == 0
+        cfg_db = db.cfgdb_clients['']
+        data = cfg_db.get_entry('SYSLOG_CONFIG_FEATURE', 'pmon')
+        assert data['rate_limit_burst'] == '200'
+        assert data['rate_limit_interval'] == '2'
+        
+    @mock.patch('config.syslog.clicommon.run_command', mock.MagicMock(return_value=('', 0)))
+    def test_enable_syslog_rate_limit_feature(self, setup_cmd_module):
+        _, config = setup_cmd_module
+        
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['enable'], []
+        )
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['enable'],
+            ['-n', 'default']
+        )
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['enable'],
+            ['-n', 'asic0']
+        )
+
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['enable'], ['database']
+        )
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['enable'], 
+            ['database', '-n', 'default']
+        )
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['enable'], 
+            ['database', '-n', 'asic0']
+        )
+        assert result.exit_code == 0
+    
+    @mock.patch('config.syslog.clicommon.run_command', mock.MagicMock(return_value=('', 0)))
+    def test_disable_syslog_rate_limit_feature(self, setup_cmd_module):
+        _, config = setup_cmd_module
+        
+        runner = CliRunner()
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['disable'], []
+        )
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['disable'],
+            ['-n', 'default']
+        )
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['disable'],
+            ['-n', 'asic0']
+        )
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['disable'], ['database']
+        )
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['disable'], 
+            ['database', '-n', 'default']
+        )
+        assert result.exit_code == 0
+        
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["rate-limit-feature"].commands['disable'], 
+            ['database', '-n', 'asic0']
+        )
+        assert result.exit_code == 0

--- a/tests/syslog_test.py
+++ b/tests/syslog_test.py
@@ -484,4 +484,3 @@ class TestSyslog:
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["disable"], obj=db
         )
         assert result.exit_code == SUCCESS
-        


### PR DESCRIPTION
Build dependency https://github.com/sonic-net/sonic-buildimage/pull/18459

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add multi ASIC support for syslog rate limit feature

#### How I did it

1. `show syslog rate-limit-container` add a new option namespace
2. `config syslog rate-limit-container` add a new option namespace
3. `config syslog rate-limit-feature` enable add a new option namespace and a new argument service_name
4. `config syslog rate-limit-feature` disable add a new option namespace and a new argument service_name

#### How to verify it

Manual test

#### Previous command output (if the output of a command-line utility has changed)

show syslog rate-limit-container help:
```
show syslog rate-limit-container --help
Usage: show syslog rate-limit-container [OPTIONS] <service_name>

  Show syslog rate limit configuration for containers

Options:
  -h, -?, --help  Show this message and exit.
```

config syslog rate-limit-container help
```
sudo config syslog rate-limit-container --help
Usage: config syslog rate-limit-container [OPTIONS] SERVICE_NAME

  Configure syslog rate limit for containers

Options:
  -i, --interval INTEGER RANGE  Configures syslog rate limit interval in
                                seconds for specified containers
  -b, --burst INTEGER RANGE     Configures syslog rate limit burst in number
                                of messages for specified containers
  -h, -?, --help                Show this message and exit.
```

config syslog rate-limit-feature enable help
```
sudo config syslog rate-limit-feature enable --help
Usage: config syslog rate-limit-feature enable [OPTIONS]

  Enable syslog rate limit feature

Options:
  -?, -h, --help  Show this message and exit.
```

config syslog rate-limit-feature disable help
```
sudo config syslog rate-limit-feature disable --help
Usage: config syslog rate-limit-feature disable [OPTIONS]

  Disable syslog rate limit feature

Options:
  -h, -?, --help  Show this message and exit.
```

#### New command output (if the output of a command-line utility has changed)

show syslog rate-limit-container help:
```
show syslog rate-limit-container --help
Usage: show syslog rate-limit-container [OPTIONS] <service_name>

  Show syslog rate limit configuration for containers

Options:
  -n, --namespace [asic0|asic1|asic2|asic3|default]
                                  Namespace name or all
  -h, -?, --help                  Show this message and exit.
```

[new] show all config in multi ASIC platforms:
```
show syslog rate-limit-container 
SERVICE         INTERVAL    BURST
--------------  ----------  -------
database        500         40000
dhcp_relay      300         20000
eventd          300         20000
gnmi            300         20000
lldp            300         20000
mgmt-framework  300         20000
mux             300         20000
nat             300         20000
pmon            50          50000
radv            300         20000
sflow           300         20000
snmp            300         20000


Namespace asic0:
SERVICE    INTERVAL    BURST
---------  ----------  -------
bgp        50          50000
database   500         40000
gbsyncd    300         20000
macsec     300         20000
swss       300         20000
syncd      300         20000
teamd      300         20000


Namespace asic1:
SERVICE    INTERVAL    BURST
---------  ----------  -------
bgp        50          50000
database   50          50000
gbsyncd    300         20000
macsec     300         20000
swss       300         20000
syncd      300         20000
teamd      300         20000


Namespace asic2:
SERVICE    INTERVAL    BURST
---------  ----------  -------
bgp        50          50000
database   50          50000
gbsyncd    300         20000
macsec     300         20000
swss       300         20000
syncd      300         20000
teamd      300         20000


Namespace asic3:
SERVICE    INTERVAL    BURST
---------  ----------  -------
bgp        50          50000
database   50          50000
gbsyncd    300         20000
macsec     300         20000
swss       300         20000
syncd      300         20000
teamd      300         20000
```

[new] show global namespace configuration:
```
show syslog rate-limit-container -n default
SERVICE         INTERVAL    BURST
--------------  ----------  -------
database        500         40000
dhcp_relay      300         20000
eventd          300         20000
gnmi            300         20000
lldp            300         20000
mgmt-framework  300         20000
mux             300         20000
nat             300         20000
pmon            50          50000
radv            300         20000
sflow           300         20000
snmp            300         20000
```

[new] show configuration for a given namespace:
```
show syslog rate-limit-container -n asic0
Namespace asic0:
SERVICE    INTERVAL    BURST
---------  ----------  -------
bgp        50          50000
database   500         40000
gbsyncd    300         20000
macsec     300         20000
swss       300         20000
syncd      300         20000
teamd      300         20000
```

config syslog rate-limit-container help:
```
sudo config syslog rate-limit-container --help
Usage: config syslog rate-limit-container [OPTIONS] SERVICE_NAME

  Configure syslog rate limit for containers

Options:
  -i, --interval INTEGER RANGE    Configures syslog rate limit interval in
                                  seconds for specified containers
  -b, --burst INTEGER RANGE       Configures syslog rate limit burst in number
                                  of messages for specified containers
  -n, --namespace [asic0|asic1|asic2|asic3|default]
                                  Namespace name or all
  -h, -?, --help                  Show this message and exit.
```

sudo config syslog rate-limit-feature enable help
```
sudo config syslog rate-limit-feature enable --help
Usage: config syslog rate-limit-feature enable [OPTIONS] [SERVICE_NAME]

  Enable syslog rate limit feature

Options:
  -n, --namespace [asic0|asic1|asic2|asic3|default]
                                  Namespace name or all
  -h, -?, --help                  Show this message and exit.
```

sudo config syslog rate-limit-feature disable help
```
sudo config syslog rate-limit-feature disable --help
Usage: config syslog rate-limit-feature disable [OPTIONS] [SERVICE_NAME]

  Disable syslog rate limit feature

Options:
  -n, --namespace [asic0|asic1|asic2|asic3|default]
                                  Namespace name or all
  -h, -?, --help                  Show this message and exit.
```