### PR TITLE
Add a command to update log level and refresh configuration

### DIFF
--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -10713,6 +10713,35 @@ This command is used to disable syslog rate limit feature.
   config syslog rate-limit-feature disable database -n asci0
   ```
 
+**config syslog level**
+
+This command is used to configure log level for a given log identifier.
+
+- Usage:
+  ```
+  config syslog level -c <log_identifier> -l <log_level> --service [<service_name>] --program [<program_name>]
+
+  config syslog level -c <log_identifier> -l <log_level> --service [<service_name>] --pid [<process_id>]
+
+  config syslog level -c <log_identifier> -l <log_level> ---pid [<process_id>]
+  ```
+
+- Example:
+
+  ```
+  # Update the log level without refresh the configuration
+  config syslog level -c xcvrd -l DEBUG
+
+  # Update the log level and send SIGHUP to xcvrd running in PMON
+  config syslog level -c xcvrd -l DEBUG --service pmon --program xcvrd
+
+  # Update the log level and send SIGHUP to PID 20 running in PMON
+  config syslog level -c xcvrd -l DEBUG --service pmon --pid 20
+
+  # Update the log level and send SIGHUP to PID 20 running in host
+  config syslog level -c xcvrd -l DEBUG --pid 20
+  ```
+
 Go Back To [Beginning of the document](#) or [Beginning of this section](#syslog)
 
 ## System State

--- a/tests/syslog_test.py
+++ b/tests/syslog_test.py
@@ -484,3 +484,65 @@ class TestSyslog:
             config.config.commands["syslog"].commands["rate-limit-feature"].commands["disable"], obj=db
         )
         assert result.exit_code == SUCCESS
+
+
+    @mock.patch('config.syslog.clicommon.run_command')
+    def test_config_log_level(self, mock_run):
+        db = Db()
+        db.cfgdb.set_entry('LOGGER', 'log1', {'require_manual_refresh': 'true'})
+
+        runner = CliRunner()
+
+        mock_run.return_value = ('something', 0)
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["level"],
+            ['-c', 'component', '-l', 'DEBUG'], obj=db
+        )
+        assert result.exit_code == SUCCESS
+
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["level"],
+            ['-c', 'component', '-l', 'DEBUG', '--pid', '123'], obj=db
+        )
+        assert result.exit_code == SUCCESS
+
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["level"],
+            ['-c', 'component', '-l', 'DEBUG', '--service', 'pmon', '--pid', '123'], obj=db
+        )
+        assert result.exit_code == SUCCESS
+
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["level"],
+            ['-c', 'component', '-l', 'DEBUG', '--service', 'pmon', '--program', 'xcvrd'], obj=db
+        )
+        assert result.exit_code == SUCCESS
+
+
+    @mock.patch('config.syslog.clicommon.run_command')
+    def test_config_log_level_negative(self, mock_run):
+        db = Db()
+
+        runner = CliRunner()
+
+        mock_run.return_value = ('something', 0)
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["level"],
+            ['-c', 'log1', '-l', 'DEBUG', '--service', 'pmon'], obj=db
+        )
+        assert result.exit_code != SUCCESS
+
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["level"],
+            ['-c', 'log1', '-l', 'DEBUG', '--program', 'xcvrd'], obj=db
+        )
+        assert result.exit_code != SUCCESS
+
+        mock_run.reset_mock()
+        result = runner.invoke(
+            config.config.commands["syslog"].commands["level"],
+            ['-c', 'log1', '-l', 'DEBUG', '--service', 'swss', '--program', 'orchagent'], obj=db
+        )
+        assert result.exit_code == SUCCESS
+        # Verify it does not send signal to orchagent if require_manual_refresh is not true
+        assert mock_run.call_count == 1


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Add a command "config syslog level" to set log level at runtime.

#### How I did it

Add a command "config syslog level" to set log level at runtime. This command shall update log level in CONFIG DB and send SIGHUP to relevant daemon if it requires a manual refresh

#### How to verify it

manual test
new unit test case

#### Previous command output (if the output of a command-line utility has changed)

N/A

#### New command output (if the output of a command-line utility has changed)

```
root@sonic:/home/admin# config syslog level --help
Usage: config syslog level [OPTIONS]

  Configure log level

Options:
  -c, --component TEXT            Component name in DB for which loglevel is
                                  applied (provided with -l)  [required]
  -l, --level [DEBUG|INFO|NOTICE|WARN|ERROR]
                                  Loglevel value  [required]
  --service TEXT                  Container name to which the SIGHUP is sent
                                  (provided with --pid or --program)
  --program TEXT                  Program name to which the SIGHUP is sent
                                  (provided with --service)
  --pid TEXT                      Process ID to which the SIGHUP is sent
                                  (provided with --service if PID is from
                                  container)
  -?, -h, --help                  Show this message and exit.
```

