### PR TITLE
[sfputil][sfpshow] Use unified format to show CMIS EEPROM

### DIFF
--- a/scripts/sfpshow
+++ b/scripts/sfpshow
@@ -378,7 +378,7 @@ class SFPShow(object):
         channel_threshold_align = 18
         module_threshold_align = 15
 
-        if sfp_type.startswith('QSFP') or sfp_type.startswith('OSFP'):
+        if sfp_type.startswith('QSFP') or is_sfp_cmis:
             # Channel Monitor
             if is_sfp_cmis:
                 output_dom += (indent + 'ChannelMonitorValues:\n')

--- a/sfputil/main.py
+++ b/sfputil/main.py
@@ -396,7 +396,7 @@ def convert_dom_to_output_string(sfp_type, is_sfp_cmis, dom_info_dict):
     channel_threshold_align = 18
     module_threshold_align = 15
 
-    if sfp_type.startswith('QSFP') or sfp_type.startswith('OSFP'):
+    if sfp_type.startswith('QSFP') or is_sfp_cmis:
         # Channel Monitor
         if is_sfp_cmis:
             output_dom += (indent + 'ChannelMonitorValues:\n')


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Use unified format to show CMIS EEPROM. The current design checks the SFP type start with "QSFP" and "OSFP". However, there could be other CMIS module such as "CPO". This PR is to fix the issue.

#### How I did it

If sfp type is start from "OSFP" or the sfp is a CMIS, we will use the same output format.

#### How to verify it

sonic-utilities UT passed
Manual test passed

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

